### PR TITLE
Vectorize framebuffer color mapping

### DIFF
--- a/src/vic/color/color.py
+++ b/src/vic/color/color.py
@@ -1,18 +1,24 @@
-COLORS = [
-    (0, 0, 0),  # Black
-    (255, 255, 255),  # White
-    (136, 0, 0),  # Red
-    (170, 255, 238),  # Cyan
-    (204, 68, 204),  # Purple
-    (0, 204, 85),  # Green
-    (0, 0, 170),  # Blue
-    (238, 238, 119),  # Yellow
-    (221, 136, 85),  # Orange
-    (102, 68, 0),  # Brown
-    (255, 119, 119),  # Light Red
-    (51, 51, 51),  # Dark Grey
-    (119, 119, 119),  # Grey
-    (170, 255, 102),  # Light Green
-    (0, 136, 255),  # Light Blue
-    (187, 187, 187),  # Light Grey
-]
+import numpy as np
+
+# Precomputed RGB values for the 16 C64 colors.
+COLORS: np.ndarray = np.array(
+    [
+        (0, 0, 0),  # Black
+        (255, 255, 255),  # White
+        (136, 0, 0),  # Red
+        (170, 255, 238),  # Cyan
+        (204, 68, 204),  # Purple
+        (0, 204, 85),  # Green
+        (0, 0, 170),  # Blue
+        (238, 238, 119),  # Yellow
+        (221, 136, 85),  # Orange
+        (102, 68, 0),  # Brown
+        (255, 119, 119),  # Light Red
+        (51, 51, 51),  # Dark Grey
+        (119, 119, 119),  # Grey
+        (170, 255, 102),  # Light Green
+        (0, 136, 255),  # Light Blue
+        (187, 187, 187),  # Light Grey
+    ],
+    dtype=np.uint8,
+)

--- a/src/vic/render.py
+++ b/src/vic/render.py
@@ -199,9 +199,8 @@ class Render:
 
     def update_pygame_display(self) -> None:
         """Updates the Pygame window with the rendered frame."""
-        for y in range(self.native_height):
-            for x in range(self.native_width):
-                self.rgb_framebuffer[x, y] = COLORS[self.framebuffer[x, y]]
+        # Vectorized color lookup to convert the indexed framebuffer into RGB.
+        self.rgb_framebuffer[:] = COLORS[self.framebuffer]
 
         surface: pygame.Surface = pygame.surfarray.make_surface(self.rgb_framebuffer)
         scaled_surface: pygame.Surface = pygame.transform.scale(


### PR DESCRIPTION
## Summary
- represent C64 color table as a NumPy array
- vectorize framebuffer color lookup in `update_pygame_display`

## Testing
- `ruff check .`
- `SDL_VIDEODRIVER=dummy pytest` *(fails: ROM file not found)*
- `python - <<'PY' ... PY`

------
https://chatgpt.com/codex/tasks/task_e_68b07660dde4832ebef5d2cacf725f5d