### PR TITLE
Add integration tests for bus memory mapping

### DIFF
--- a/tests/integration/bus/conftest.py
+++ b/tests/integration/bus/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+
+from src.bus.bus import Bus
+from src.bus.memory.rom import ROM
+
+
+@pytest.fixture
+def bus(monkeypatch):
+    """Inicjalizuje magistralę w trybie testowym z zaślepkami ROM."""
+
+    def fake_post_init(self):
+        self.data = bytes([i % 256 for i in range(self.size)])
+
+    monkeypatch.setattr(ROM, "__post_init__", fake_post_init, raising=False)
+    b = Bus()
+    yield b
+    b.ram.close()
+    b.color_ram.close()

--- a/tests/integration/bus/test_bus.py
+++ b/tests/integration/bus/test_bus.py
@@ -1,0 +1,36 @@
+def test_ram_read_write(bus) -> None:
+    address = 0x0002
+    value = 0xAA
+    bus.write(address, value)
+    assert bus.read(address) == value
+
+
+def test_rom_read_write(bus) -> None:
+    address = 0xA123
+    value = 0x55
+    expected = (address - 0xA000) % 256
+    assert bus.read(address) == expected
+    bus.write(address, value)
+    assert bus.read(address) == expected
+    assert bus.ram.read(address) == value
+
+
+def test_color_ram_read_write(bus) -> None:
+    bus.write(0x0001, 0x37)
+    address = 0xD900
+    bus.write(address, 0xAB)
+    assert bus.read(address) == 0x0B
+
+
+def test_pla_address_mapping(bus) -> None:
+    bus.write(0x0001, 0x33)
+    assert bus.pla.decode_address(0x0002) is bus.ram
+    assert bus.pla.decode_address(0xA000) is bus.basic_rom
+    assert bus.pla.decode_address(0xE000) is bus.kernel_rom
+    assert bus.pla.decode_address(0x1000) is bus.chargen_rom
+    bus.write(0x0001, 0x37)
+    assert bus.pla.decode_address(0xD020) is bus.vic
+    assert bus.pla.decode_address(0xD400) is bus.sid
+    assert bus.pla.decode_address(0xDC00) is bus.cia_1
+    assert bus.pla.decode_address(0xDD00) is bus.cia_2
+    assert bus.pla.decode_address(0xD800) is bus.color_ram


### PR DESCRIPTION
## Summary
- add bus fixture with ROM stubs for predictable behavior in tests
- test RAM, ROM, and Color RAM read/write operations
- verify PLA address decoding for key memory regions

## Testing
- `ruff check .`
- `pytest tests/integration/bus -q`

------
https://chatgpt.com/codex/tasks/task_e_68b0766f449c832e99c62e29fc93db1f