### PR TITLE
Refactor logging setup for debug flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,14 @@ python main.py
 
 Press **Esc** or close the window to quit.
 
+### Debug logging
+
+Run the emulator with verbose debug logs:
+
+```bash
+python main.py --debug
+```
+
 
 ## UML Diagrams
 

--- a/main.py
+++ b/main.py
@@ -1,8 +1,19 @@
+import argparse
+
 from src.emulator.emulator import C64Emulator
-from src.utils.log_setup import log
+from src.utils.log_setup import setup_logging
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(description="Commodore 64 Emulator")
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable debug mode with more detailed logs",
+    )
+    args = parser.parse_args()
+
+    log = setup_logging(debug=args.debug)
     emulator = C64Emulator()
 
     try:

--- a/src/utils/log_setup.py
+++ b/src/utils/log_setup.py
@@ -1,25 +1,24 @@
-import argparse
 import logging
 
+log: logging.Logger = logging.getLogger("C64Emulator")
 
-def setup_logging() -> logging.Logger:
+
+def setup_logging(*, debug: bool = False) -> logging.Logger:
     """
-    Configures global logging for the Commodore 64 Emulator.
+    Configure global logging for the Commodore 64 Emulator.
 
-    :return: Configured logger instance.
+    Parameters
+    ----------
+    debug: bool
+        Enables debug mode with more detailed logs.
+
+    Returns
+    -------
+    logging.Logger
+        Configured logger instance.
+
     """
-    parser: argparse.ArgumentParser = argparse.ArgumentParser(
-        description="Commodore 64 Emulator Logging Setup"
-    )
-    parser.add_argument(
-        "--debug",
-        action="store_true",
-        help="Enables debug mode with more detailed logs",
-    )
-    args, _ = parser.parse_known_args()
-
-    debug_enabled: bool = args.debug
-    level: int = logging.DEBUG if debug_enabled else logging.INFO
+    level: int = logging.DEBUG if debug else logging.INFO
 
     logging.basicConfig(
         level=level,
@@ -27,10 +26,7 @@ def setup_logging() -> logging.Logger:
         datefmt="%Y-%m-%d %H:%M:%S",
     )
 
-    logger: logging.Logger = logging.getLogger("C64Emulator")
-    logger.info("Logging configured")
+    log.setLevel(level)
+    log.info("Logging configured")
 
-    return logger
-
-
-log: logging.Logger = setup_logging()
+    return log


### PR DESCRIPTION
## Summary
- refactor logging setup to accept a debug flag instead of parsing args on import
- parse CLI debug flag in `main.py`
- document debug mode in README

## Testing
- `ruff check .`
- `pytest` *(fails: ROM file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b07667ce54832e92ec707785da1f21